### PR TITLE
fix an improperly configured baseurl, which was causing links to have //

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,8 +5,8 @@ title: Plumatic Blog
 #  Write an awesome description for your new site here. You can edit this
 #  line in _config.yml. It will appear in your document head meta (for
 #  Google search results) and in your feed.xml site description.
-baseurl: "https://plumatic.github.io/" # the subpath of your site, e.g. /blog/
-url: "https://github.com/plumatic/"
+baseurl: "" # the subpath of your site, e.g. /blog/
+url: "https://plumatic.github.io/"
 #twitter_username: jekyllrb
 #github_username:  jekyll
 #


### PR DESCRIPTION
hey there, was poking around on [this library](https://github.com/plumatic/plumbing) and wanted to see the linked strange loop post, but got a 404 from the link.

turns out i think jekyll is creating an extra `/` character in links to posts on your site, e.g. the about link is:

```
https://plumatic.github.io//about/
```

other posts:

```
https://plumatic.github.io//prismatics-graph-at-strange-loop
```

etc. i'm not a jekyll expert but i'm guessing this isn't desired behavior! 

i believe this is due to a misconfigured `baseurl`, which this PR fixes. you can read more about this [here](https://byparker.com/blog/2014/clearing-up-confusion-around-baseurl/). but basically since the blog is in the root path, you don't need `baseurl`, it seems... 